### PR TITLE
Updated VER in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ OSSO build of the Bcg729 G729 speech codec
 
 Get source::
 
-    VER=1.0.3
+    VER=1.0.4
     curl \
       https://codeload.github.com/BelledonneCommunications/bcg729/tar.gz/$VER \
       >bcg729_$VER.orig.tar.gz


### PR DESCRIPTION
Updated the VER variable. Using the old version there makes the installation fail with
```
dpkg-source: error: can't build with source format '3.0 (quilt)': no upstream tarball found at ../bcg729_1.0.4.orig.tar.{bz2,gz,lzma,xz}
dpkg-buildpackage: error: dpkg-source -b bcg729-1.0.3 gave error exit status 255```